### PR TITLE
Update to remove provider and api-key-reference. Add dataset creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,12 @@
-# Terraform configuration
-
-terraform {
-  required_providers {
-    honeycombio = {
-      source  = "honeycombio/honeycombio"
-      version = ">= 0.10.0"
-    }
-  }
+####################################################
+# Create Dataset to Contain all Required Columns
+####################################################
+resource "honeycombio_dataset" "refinery-logs-dataset" {
+  name        = var.refinery_logs_dataset
+  description = "Dataset for Refinery logs"
 }
 
-provider "honeycombio" {
-  api_key = var.honeycomb_api_key
-  # You can supply this via the environment variable HONEYCOMB_API_KEY or by setting the value in a .tfvars file
+resource "honeycombio_dataset" "refinery-metrics-dataset" {
+  name        = var.refinery_metrics_dataset
+  description = "Dataset for Refinery metrics"
 }

--- a/query_refinery_health.tf
+++ b/query_refinery_health.tf
@@ -1,3 +1,46 @@
+resource "honeycombio_column" "collect_cache_buffer_overrun" {
+  key_name = "collect_cache_buffer_overrun"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
+
+resource "honeycombio_column" "memory_inuse" {
+  key_name = "memory_inuse"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
+
+resource "honeycombio_column" "collect_cache_entries_max" {
+  key_name = "collect_cache_entries_max"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
+
+resource "honeycombio_column" "collect_cache_capacity" {
+  key_name = "collect_cache_capacity"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
+
+resource "honeycombio_column" "num_goroutines" {
+  key_name = "num_goroutines"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
+
+resource "honeycombio_column" "process_uptime_seconds" {
+  key_name = "process_uptime_seconds"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
+
+resource "honeycombio_column" "hostname" {
+  key_name = "hostname"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
+
+
 data "honeycombio_query_specification" "refinery-health" {
   calculation {
     op     = "SUM"
@@ -31,6 +74,16 @@ data "honeycombio_query_specification" "refinery-health" {
 
   breakdowns = ["hostname"]
   time_range = 86400
+
+  depends_on = [
+    honeycombio_column.collect_cache_buffer_overrun,
+    honeycombio_column.memory_inuse,
+    honeycombio_column.collect_cache_entries_max,
+    honeycombio_column.collect_cache_capacity,
+    honeycombio_column.num_goroutines,
+    honeycombio_column.process_uptime_seconds,
+    honeycombio_column.hostname,
+  ]
 }
 
 resource "honeycombio_query" "refinery-health-query" {

--- a/query_refinery_health.tf
+++ b/query_refinery_health.tf
@@ -1,43 +1,43 @@
 resource "honeycombio_column" "collect_cache_buffer_overrun" {
   key_name = "collect_cache_buffer_overrun"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 resource "honeycombio_column" "memory_inuse" {
   key_name = "memory_inuse"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 resource "honeycombio_column" "collect_cache_entries_max" {
   key_name = "collect_cache_entries_max"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 resource "honeycombio_column" "collect_cache_capacity" {
   key_name = "collect_cache_capacity"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 resource "honeycombio_column" "num_goroutines" {
   key_name = "num_goroutines"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 resource "honeycombio_column" "process_uptime_seconds" {
   key_name = "process_uptime_seconds"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 resource "honeycombio_column" "hostname" {
   key_name = "hostname"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 

--- a/query_refinery_intercommunication.tf
+++ b/query_refinery_intercommunication.tf
@@ -1,13 +1,13 @@
 resource "honeycombio_column" "incoming_router_span" {
   key_name = "incoming_router_span"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 resource "honeycombio_column" "peer_router_batch" {
   key_name = "peer_router_batch"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 data "honeycombio_query_specification" "refinery-intercommunication" {

--- a/query_refinery_intercommunication.tf
+++ b/query_refinery_intercommunication.tf
@@ -1,3 +1,15 @@
+resource "honeycombio_column" "incoming_router_span" {
+  key_name = "incoming_router_span"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
+
+resource "honeycombio_column" "peer_router_batch" {
+  key_name = "peer_router_batch"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
+
 data "honeycombio_query_specification" "refinery-intercommunication" {
   calculation {
     op     = "SUM"
@@ -17,6 +29,12 @@ data "honeycombio_query_specification" "refinery-intercommunication" {
 
   breakdowns = ["hostname"]
   time_range = 86400
+
+  depends_on = [
+    honeycombio_column.incoming_router_span,
+    honeycombio_column.peer_router_batch,
+    honeycombio_column.hostname,
+  ]
 }
 
 resource "honeycombio_query" "refinery-intercommunication-query" {

--- a/query_refinery_receive_buffers.tf
+++ b/query_refinery_receive_buffers.tf
@@ -1,13 +1,13 @@
 resource "honeycombio_column" "incoming_router_dropped" {
   key_name = "incoming_router_dropped"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 resource "honeycombio_column" "peer_router_dropped" {
   key_name = "peer_router_dropped"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 data "honeycombio_query_specification" "refinery-receive-buffers" {

--- a/query_refinery_receive_buffers.tf
+++ b/query_refinery_receive_buffers.tf
@@ -1,3 +1,15 @@
+resource "honeycombio_column" "incoming_router_dropped" {
+  key_name = "incoming_router_dropped"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
+
+resource "honeycombio_column" "peer_router_dropped" {
+  key_name = "peer_router_dropped"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
+
 data "honeycombio_query_specification" "refinery-receive-buffers" {
   calculation {
     op     = "SUM"
@@ -11,6 +23,12 @@ data "honeycombio_query_specification" "refinery-receive-buffers" {
 
   breakdowns = ["hostname"]
   time_range = 86400
+
+  depends_on = [
+    honeycombio_column.incoming_router_dropped,
+    honeycombio_column.peer_router_dropped,
+    honeycombio_column.hostname,
+  ]
 }
 
 resource "honeycombio_query" "refinery-receive-buffers-query" {

--- a/query_refinery_sampling_decision.tf
+++ b/query_refinery_sampling_decision.tf
@@ -1,3 +1,21 @@
+resource "honeycombio_column" "trace_accepted" {
+  key_name = "trace_accepted"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
+
+resource "honeycombio_column" "trace_send_dropped" {
+  key_name = "trace_send_dropped"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
+
+resource "honeycombio_column" "trace_send_kept" {
+  key_name = "trace_send_kept"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
+
 data "honeycombio_query_specification" "refinery-sampling-decision" {
   calculation {
     op     = "MAX"
@@ -22,6 +40,13 @@ data "honeycombio_query_specification" "refinery-sampling-decision" {
 
   breakdowns = ["hostname"]
   time_range = 86400
+
+  depends_on = [
+    honeycombio_column.trace_accepted,
+    honeycombio_column.trace_send_dropped,
+    honeycombio_column.trace_send_kept,
+    honeycombio_column.hostname,
+  ]
 }
 
 resource "honeycombio_query" "refinery-sampling-decision-query" {

--- a/query_refinery_sampling_decision.tf
+++ b/query_refinery_sampling_decision.tf
@@ -1,19 +1,19 @@
 resource "honeycombio_column" "trace_accepted" {
   key_name = "trace_accepted"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 resource "honeycombio_column" "trace_send_dropped" {
   key_name = "trace_send_dropped"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 resource "honeycombio_column" "trace_send_kept" {
   key_name = "trace_send_kept"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 data "honeycombio_query_specification" "refinery-sampling-decision" {

--- a/query_refinery_send_buffers.tf
+++ b/query_refinery_send_buffers.tf
@@ -12,20 +12,20 @@ resource "honeycombio_column" "libhoney_peer_send_errors" {
 
 resource "honeycombio_column" "libhoney_upstream_queue_length" {
   key_name = "libhoney_upstream_queue_length"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 resource "honeycombio_column" "upstream_enqueue_errors" {
   key_name = "upstream_enqueue_errors"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 resource "honeycombio_column" "upstream_response_errors" {
   key_name = "upstream_response_errors"
-  type = "float"
-  dataset = var.refinery_metrics_dataset
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
 }
 
 data "honeycombio_query_specification" "refinery-send-buffers" {

--- a/query_refinery_send_buffers.tf
+++ b/query_refinery_send_buffers.tf
@@ -10,6 +10,23 @@ resource "honeycombio_column" "libhoney_peer_send_errors" {
   dataset  = var.refinery_metrics_dataset
 }
 
+resource "honeycombio_column" "libhoney_upstream_queue_length" {
+  key_name = "libhoney_upstream_queue_length"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
+
+resource "honeycombio_column" "upstream_enqueue_errors" {
+  key_name = "upstream_enqueue_errors"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
+
+resource "honeycombio_column" "upstream_response_errors" {
+  key_name = "upstream_response_errors"
+  type = "float"
+  dataset = var.refinery_metrics_dataset
+}
 
 data "honeycombio_query_specification" "refinery-send-buffers" {
   calculation {
@@ -43,6 +60,10 @@ data "honeycombio_query_specification" "refinery-send-buffers" {
   depends_on = [
     honeycombio_column.libhoney_peer_queue_overflow,
     honeycombio_column.libhoney_peer_send_errors,
+    honeycombio_column.libhoney_upstream_queue_length,
+    honeycombio_column.upstream_enqueue_errors,
+    honeycombio_column.upstream_response_errors,
+    honeycombio_column.hostname,
   ]
 }
 

--- a/query_refinery_trace_indicators.tf
+++ b/query_refinery_trace_indicators.tf
@@ -1,3 +1,15 @@
+resource "honeycombio_column" "trace_sent_cache_hit" {
+  key_name = "trace_sent_cache_hit"
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
+}
+
+resource "honeycombio_column" "trace_send_no_root" {
+  key_name = "trace_send_no_root"
+  type     = "float"
+  dataset  = var.refinery_metrics_dataset
+}
+
 data "honeycombio_query_specification" "refinery-trace-indicators" {
   calculation {
     op     = "SUM"
@@ -10,6 +22,11 @@ data "honeycombio_query_specification" "refinery-trace-indicators" {
   }
 
   time_range = 86400
+
+  depends_on = [
+    honeycombio_column.trace_sent_cache_hit,
+    honeycombio_column.trace_send_no_root,
+  ]
 }
 
 resource "honeycombio_query" "refinery-trace-indicators-query" {

--- a/variables.tf
+++ b/variables.tf
@@ -15,10 +15,3 @@ variable "refinery_cluster_name" {
   type        = string
   default     = "Production"
 }
-
-variable "honeycomb_api_key" {
-  description = "Honeycomb API key"
-  type        = string
-  default     = null
-  # You can supply this via the environment variable HONEYCOMB_API_KEY or by setting the value in a .tfvars file
-}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    honeycombio = {
+      source  = "honeycombio/honeycombio"
+      version = ">= 0.10.0"
+    }
+  }
+}


### PR DESCRIPTION
## Which problem is this PR solving?

- Closes #6 and #7 

## Short description of the changes

- Creates the dataset in the environment if those don't already exist
- Removes the provider declaration for honeycombio as that's not necessary and makes it so things like `count` cannot be used when utilizing this module.
